### PR TITLE
Add JoinMarket

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,14 @@
             <td><a href="https://twitter.com/FOUNDATIONdvcs/status/1731372779360915780">Released in v1.4</a></td>
           </tr>
  
-          
+          <tr>
+            <th scope="row" class="text-start">JoinMarket <a href="https://github.com/JoinMarket-Org/joinmarket-clientserver">
+              <svg class="bi" width="24" height="24"> <use xlink:href="#external-link"/>
+                  </svg></a></th>
+            <td><svg class="bi" width="24" height="24"><use xlink:href="#check"/></svg></td>
+            <td></td>
+            <td><a href="https://github.com/dennisreimann/joinmarket-log-parser">Using JoinMarket Log Parser</a></td>
+          </tr>
 
 
           <tr>


### PR DESCRIPTION
There isn't native BIP329 support in JoinMarket yet (but there's [open issue about that](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1434)), but label export is currently possible using third party [JoinMarket Log Parser](https://github.com/dennisreimann/joinmarket-log-parser) tool.