### PR TITLE
Add Keeper full compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,9 +312,9 @@
             <th scope="row" class="text-start">Keeper <a href="https://bitcoinkeeper.app/">
               <svg class="bi" width="24" height="24"> <use xlink:href="#external-link"/></svg></a>
             </th>
-            <td></td>
-            <td></td>
-            <td><a href="https://twitter.com/bitcoinKeeper_/status/1706215571249922269">UI needed for import/export</a></td>
+            <td><svg class="bi" width="24" height="24"><use xlink:href="#check"/></svg></td>
+            <td><svg class="bi" width="24" height="24"><use xlink:href="#check"/></svg></td>
+            <td><a href="https://github.com/bithyve/bitcoin-keeper/releases/tag/v2.2.0">Released in v2.2.0</a></td>
           </tr>
 
           <tr>


### PR DESCRIPTION
With the latest release of v2.2.0, Bitcoin Keeper now supports import and export of BIP329 labels.